### PR TITLE
Require sign by address to add and update CATs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@nestjs/common": "^9.0.0",
         "@nestjs/core": "^9.0.0",
         "@nestjs/platform-express": "^9.0.0",
-        "@tail-database/tail-database-client": "^1.5.0",
+        "@tail-database/tail-database-client": "^1.6.1",
         "axios": "^1.1.3",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.13.2",
@@ -1779,9 +1779,9 @@
       }
     },
     "node_modules/@tail-database/tail-database-client": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@tail-database/tail-database-client/-/tail-database-client-1.5.0.tgz",
-      "integrity": "sha512-82MIB9ktoK6f5WPlISGebtzClnf9Nh0IqyGGVnRznym9qlUWOreZm8bIJBzzEa08y1ycJzvefd8+czK1HSuSjA==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@tail-database/tail-database-client/-/tail-database-client-1.6.1.tgz",
+      "integrity": "sha512-RH8tkbNLuocDkObK7YJl88YkNrFkb3rGZZ9fEZ6Zb0Cb5HpQ0k0MODKxS9Biy/cYlQeh+fdfrzG15huHhNEKRg==",
       "dependencies": {
         "@types/node": "^18.11.9",
         "axios": "^1.1.3",
@@ -9794,9 +9794,9 @@
       }
     },
     "@tail-database/tail-database-client": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@tail-database/tail-database-client/-/tail-database-client-1.5.0.tgz",
-      "integrity": "sha512-82MIB9ktoK6f5WPlISGebtzClnf9Nh0IqyGGVnRznym9qlUWOreZm8bIJBzzEa08y1ycJzvefd8+czK1HSuSjA==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@tail-database/tail-database-client/-/tail-database-client-1.6.1.tgz",
+      "integrity": "sha512-RH8tkbNLuocDkObK7YJl88YkNrFkb3rGZZ9fEZ6Zb0Cb5HpQ0k0MODKxS9Biy/cYlQeh+fdfrzG15huHhNEKRg==",
       "requires": {
         "@types/node": "^18.11.9",
         "axios": "^1.1.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.1",
       "license": "UNLICENSED",
       "dependencies": {
+        "@chiamine/bls-signatures": "^0.2.1-beta.2",
         "@nestjs/common": "^9.0.0",
         "@nestjs/core": "^9.0.0",
         "@nestjs/platform-express": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "test:e2e": "jest --config ./test/jest-e2e.json"
   },
   "dependencies": {
+    "@chiamine/bls-signatures": "^0.2.1-beta.2",
     "@nestjs/common": "^9.0.0",
     "@nestjs/core": "^9.0.0",
     "@nestjs/platform-express": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@nestjs/common": "^9.0.0",
     "@nestjs/core": "^9.0.0",
     "@nestjs/platform-express": "^9.0.0",
-    "@tail-database/tail-database-client": "^1.5.0",
+    "@tail-database/tail-database-client": "^1.6.1",
     "axios": "^1.1.3",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.13.2",

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Logger, Param, Post } from '@nestjs/common';
+import { BadRequestException, Body, Controller, Logger, Param, Post } from '@nestjs/common';
 import { convertbits, encode } from 'src/bech32';
 import { TailService } from '../tail/tail.service';
 import { AuthDto } from './auth.dto';
@@ -17,7 +17,13 @@ export class AuthController {
   async getMessage(@Param('hash') hash: string, @Body() authDto: AuthDto): Promise<{ address: string; message: string; }> {
     this.logger.log('POST /auth called');
 
-    await this.tailService.validateTailHash(hash, authDto.coinId);
+    try {
+      await this.tailService.validateTailHash(hash, authDto.coinId);
+    } catch (err) {
+      console.error(err);
+
+      throw new BadRequestException('Coin ID does not match Asset ID');
+    }
 
     const message = this.authService.getAuthorizationMessage();
     const [eve_coin_id] = await this.tailService.getTailReveal(authDto.coinId);

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -1,0 +1,31 @@
+import { Controller, Get, Logger, Param } from '@nestjs/common';
+import { convertbits, encode } from 'src/bech32';
+import { TailService } from '../tail/tail.service';
+import { AuthService } from './auth.service';
+
+@Controller('auth')
+export class AuthController {
+  private readonly logger = new Logger(AuthController.name);
+
+  constructor(
+    private readonly authService: AuthService,
+    private readonly tailService: TailService,
+  ) { }
+
+  @Get(':hash')
+  async getMessage(@Param('hash') hash: string): Promise<{ address: string; message: string; }> {
+    this.logger.log('GET /auth called');
+
+    const message = this.authService.getAuthorizationMessage();
+    const puzzle_hash = await this.tailService.getEveCoinParentAddress(hash);
+    const puzzlehashBuffer = Buffer.from(puzzle_hash.slice(2), 'hex');
+    const puzzlehashArray = Array.prototype.slice.call(puzzlehashBuffer, 0);
+    const data = convertbits(puzzlehashArray, 8, 5);
+    const address = encode('xch', data, 'bech32m');
+
+    return {
+        address,
+        message
+    };
+  }
+}

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -15,7 +15,7 @@ export class AuthController {
 
   @Post(':hash')
   async getMessage(@Param('hash') hash: string, @Body() authDto: AuthDto): Promise<{ address: string; message: string; }> {
-    this.logger.log('GET /auth called');
+    this.logger.log('POST /auth called');
 
     await this.tailService.validateTailHash(hash, authDto.coinId);
 

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Get, Logger, Param } from '@nestjs/common';
+import { Body, Controller, Logger, Param, Post } from '@nestjs/common';
 import { convertbits, encode } from 'src/bech32';
 import { TailService } from '../tail/tail.service';
 import { AuthDto } from './auth.dto';
@@ -13,9 +13,11 @@ export class AuthController {
     private readonly tailService: TailService,
   ) { }
 
-  @Get(':hash')
+  @Post(':hash')
   async getMessage(@Param('hash') hash: string, @Body() authDto: AuthDto): Promise<{ address: string; message: string; }> {
     this.logger.log('GET /auth called');
+
+    await this.tailService.validateTailHash(hash, authDto.coinId);
 
     const message = this.authService.getAuthorizationMessage();
     const [eve_coin_id] = await this.tailService.getTailReveal(authDto.coinId);

--- a/src/auth/auth.dto.ts
+++ b/src/auth/auth.dto.ts
@@ -1,0 +1,8 @@
+import { IsDefined, Length, IsString } from 'class-validator';
+
+export class AuthDto {
+  @Length(64, 64)
+  @IsDefined()
+  @IsString()
+  coinId: string;
+}

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -1,0 +1,9 @@
+import { Injectable } from '@nestjs/common';
+import { getCurrentHour, sha256 } from 'src/util';
+
+@Injectable()
+export class AuthService {
+    public getAuthorizationMessage(): string {
+        return sha256(getCurrentHour().toISOString());
+    }
+}

--- a/src/bech32.ts
+++ b/src/bech32.ts
@@ -1,0 +1,165 @@
+// Copyright (c) 2017, 2021 Pieter Wuille
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+var CHARSET = 'qpzry9x8gf2tvdw0s3jn54khce6mua7l';
+var GENERATOR = [0x3b6a57b2, 0x26508e6d, 0x1ea119fa, 0x3d4233dd, 0x2a1462b3];
+
+const encodings = {
+  BECH32: "bech32",
+  BECH32M: "bech32m",
+};
+
+function getEncodingConst(enc: string): number | null {
+  if (enc == encodings.BECH32) {
+    return 1;
+  } else if (enc == encodings.BECH32M) {
+    return 0x2bc830a3;
+  } else {
+    return null;
+  }
+}
+
+function polymod(values: number[]) {
+  var chk = 1;
+  for (var p = 0; p < values.length; ++p) {
+    var top = chk >> 25;
+    chk = (chk & 0x1ffffff) << 5 ^ values[p];
+    for (var i = 0; i < 5; ++i) {
+      if ((top >> i) & 1) {
+        chk ^= GENERATOR[i];
+      }
+    }
+  }
+  return chk;
+}
+
+function hrpExpand(hrp: string) {
+  var ret = [];
+  var p;
+  for (p = 0; p < hrp.length; ++p) {
+    ret.push(hrp.charCodeAt(p) >> 5);
+  }
+  ret.push(0);
+  for (p = 0; p < hrp.length; ++p) {
+    ret.push(hrp.charCodeAt(p) & 31);
+  }
+  return ret;
+}
+
+function verifyChecksum(hrp: string, data: number[], enc: string) {
+  return polymod(hrpExpand(hrp).concat(data)) === getEncodingConst(enc);
+}
+
+function createChecksum(hrp: string, data: number[], enc: string) {
+  var values = hrpExpand(hrp).concat(data).concat([0, 0, 0, 0, 0, 0]);
+  // @ts-ignore
+  var mod = polymod(values) ^ getEncodingConst(enc);
+  var ret = [];
+  for (var p = 0; p < 6; ++p) {
+    ret.push((mod >> 5 * (5 - p)) & 31);
+  }
+  return ret;
+}
+
+function encode(hrp: string, data: number[], enc: string) {
+  var combined = data.concat(createChecksum(hrp, data, enc));
+  var ret = hrp + '1';
+  for (var p = 0; p < combined.length; ++p) {
+    ret += CHARSET.charAt(combined[p]);
+  }
+  return ret;
+}
+
+function decode(bechString: string, enc: string): { hrp: string, data: number[] } | null {
+  var p;
+  var has_lower = false;
+  var has_upper = false;
+  for (p = 0; p < bechString.length; ++p) {
+    if (bechString.charCodeAt(p) < 33 || bechString.charCodeAt(p) > 126) {
+      return null;
+    }
+    if (bechString.charCodeAt(p) >= 97 && bechString.charCodeAt(p) <= 122) {
+      has_lower = true;
+    }
+    if (bechString.charCodeAt(p) >= 65 && bechString.charCodeAt(p) <= 90) {
+      has_upper = true;
+    }
+  }
+  if (has_lower && has_upper) {
+    return null;
+  }
+  bechString = bechString.toLowerCase();
+  var pos = bechString.lastIndexOf('1');
+  if (pos < 1 || pos + 7 > bechString.length || bechString.length > 90) {
+    return null;
+  }
+  var hrp = bechString.substring(0, pos);
+  var data = [];
+  for (p = pos + 1; p < bechString.length; ++p) {
+    var d = CHARSET.indexOf(bechString.charAt(p));
+    if (d === -1) {
+      return null;
+    }
+    data.push(d);
+  }
+  if (!verifyChecksum(hrp, data, enc)) {
+    return null;
+  }
+  return { hrp: hrp, data: data.slice(0, data.length - 6) };
+}
+
+function convertbits(data: number[], frombits: number, tobits: number, pad = true): number[] | null {
+  let acc = 0;
+  let bits = 0;
+  const ret = [];
+  const maxv = (1 << tobits) - 1;
+  const max_acc = (1 << (frombits + tobits - 1)) - 1;
+
+  for (const value of data) {
+    if (value < 0 || (value >> frombits)) {
+      return null;
+    }
+
+    acc = ((acc << frombits) | value) & max_acc;
+    bits += frombits;
+
+    while (bits >= tobits) {
+      bits -= tobits;
+
+      ret.push((acc >> bits) & maxv);
+    }
+  }
+
+  if (pad) {
+    if (bits) {
+      ret.push((acc << (tobits - bits)) & maxv);
+    }
+  } else if (bits >= frombits || ((acc << (tobits - bits)) & maxv)) {
+    return null;
+  }
+
+  return ret;
+}
+
+export {
+  decode,
+  encode,
+  convertbits
+};

--- a/src/bls.ts
+++ b/src/bls.ts
@@ -1,0 +1,40 @@
+import {
+    ModuleInstance,
+    G1Element,
+    G2Element,
+} from '@chiamine/bls-signatures';
+import { Inject, Injectable } from '@nestjs/common';
+import { hex_to_buffer } from './util';
+
+@Injectable()
+export class Bls {
+    constructor(@Inject('BLS') private readonly BLS: ModuleInstance) { }
+
+    public signatureFromHex(hex: string): G2Element {
+        return G2Element.from_bytes(hex_to_buffer(hex));
+    }
+
+    public verify(
+        public_key: G1Element,
+        message: string,
+        signature: G2Element,
+    ): boolean {
+        return this.BLS.AugSchemeMPL.verify(
+            public_key,
+            hex_to_buffer(message),
+            signature,
+        );
+    }
+
+    public aggregateVerify(
+        public_keys: G1Element[],
+        messages: string[],
+        signature: G2Element,
+    ): boolean {
+        return this.BLS.AugSchemeMPL.aggregate_verify(
+            public_keys,
+            messages.map((message) => hex_to_buffer(message)),
+            signature,
+        );
+    }
+}

--- a/src/bls.ts
+++ b/src/bls.ts
@@ -14,6 +14,10 @@ export class Bls {
         return G2Element.from_bytes(hex_to_buffer(hex));
     }
 
+    public getPublicKey(hex: string): G1Element {
+        return this.BLS.G1Element.from_bytes(hex_to_buffer(hex));
+    }
+
     public verify(
         public_key: G1Element,
         message: string,

--- a/src/bls.ts
+++ b/src/bls.ts
@@ -11,7 +11,7 @@ export class Bls {
     constructor(@Inject('BLS') private readonly BLS: ModuleInstance) { }
 
     public signatureFromHex(hex: string): G2Element {
-        return G2Element.from_bytes(hex_to_buffer(hex));
+        return this.BLS.G2Element.from_bytes(hex_to_buffer(hex));
     }
 
     public getPublicKey(hex: string): G1Element {

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,6 +3,9 @@ import { TailDatabaseModule } from './tail.database.module';
 
 async function bootstrap() {
   const app = await NestFactory.create(TailDatabaseModule);
+
+  app.enableCors({ origin: '*' });
+
   await app.listen(8080);
 }
 bootstrap();

--- a/src/tail.database.module.ts
+++ b/src/tail.database.module.ts
@@ -31,6 +31,6 @@ const tail = new Tail(datalayer);
         provide: Tail,
         useValue: tail
     }, TailService, NftService, Bls, bls],
-    exports: [Tail],
+    exports: [],
 })
 export class TailDatabaseModule { }

--- a/src/tail.database.module.ts
+++ b/src/tail.database.module.ts
@@ -1,6 +1,8 @@
 import loadBls from '@chiamine/bls-signatures';
 import { Module } from '@nestjs/common';
 import { Coin, DataLayer, Tail } from '@tail-database/tail-database-client';
+import { AuthController } from './auth/auth.controller';
+import { AuthService } from './auth/auth.service';
 import { Bls } from './bls';
 import { connectionOptions } from './config/rpc.config';
 import { NftController } from './nft/nft.controller';
@@ -23,14 +25,25 @@ const tail = new Tail(datalayer);
 
 @Module({
     imports: [],
-    controllers: [TailController, NftController],
-    providers: [{
-        provide: Coin,
-        useValue: coin
-    }, {
-        provide: Tail,
-        useValue: tail
-    }, TailService, NftService, Bls, bls],
+    controllers: [
+        AuthController,
+        TailController,
+        NftController,
+    ],
+    providers: [
+        {
+            provide: Coin,
+            useValue: coin
+        }, {
+            provide: Tail,
+            useValue: tail
+        },
+        AuthService,
+        TailService,
+        NftService,
+        Bls,
+        bls
+    ],
     exports: [],
 })
 export class TailDatabaseModule { }

--- a/src/tail.database.module.ts
+++ b/src/tail.database.module.ts
@@ -1,10 +1,17 @@
+import loadBls from '@chiamine/bls-signatures';
 import { Module } from '@nestjs/common';
 import { Coin, DataLayer, Tail } from '@tail-database/tail-database-client';
+import { Bls } from './bls';
 import { connectionOptions } from './config/rpc.config';
 import { NftController } from './nft/nft.controller';
 import { NftService } from './nft/nft.service';
 import { TailController } from './tail/tail.controller';
 import { TailService } from './tail/tail.service';
+
+const bls = {
+    provide: 'BLS',
+    useFactory: async () => loadBls(),
+  };
 
 const datalayer = new DataLayer({
     ...connectionOptions,
@@ -23,7 +30,7 @@ const tail = new Tail(datalayer);
     }, {
         provide: Tail,
         useValue: tail
-    }, TailService, NftService],
+    }, TailService, NftService, Bls, bls],
     exports: [Tail],
 })
 export class TailDatabaseModule { }

--- a/src/tail.database.module.ts
+++ b/src/tail.database.module.ts
@@ -11,7 +11,7 @@ import { TailService } from './tail/tail.service';
 const bls = {
     provide: 'BLS',
     useFactory: async () => loadBls(),
-  };
+};
 
 const datalayer = new DataLayer({
     ...connectionOptions,

--- a/src/tail/tail.controller.ts
+++ b/src/tail/tail.controller.ts
@@ -55,7 +55,13 @@ export class TailController {
   async updateTail(@Headers() headers, @Body() updateTailDto: AddTailDto): Promise<void> {
     this.logger.log('PATCH /tail called');
 
-    const valid = await this.tailService.authorize(updateTailDto.hash, headers['X-Chia-Signature']);
+    const signature = headers['x-chia-signature'];
+
+    if (!signature) {
+      throw new BadRequestException('Signature is required');
+    }
+
+    const valid = await this.tailService.authorize(updateTailDto.hash, signature);
 
     if (!valid) {
       throw new BadRequestException('Invalid signature');

--- a/src/tail/tail.controller.ts
+++ b/src/tail/tail.controller.ts
@@ -4,7 +4,6 @@ import { AddTailDto } from './add.tail.dto';
 import { AddTailsDto } from './add.tails.dto';
 import { TailService } from './tail.service';
 import { NftService } from '../nft/nft.service';
-import { Bls } from 'src/bls';
 
 interface TailRevealResponse {
   eve_coin_id: string;
@@ -20,7 +19,6 @@ export class TailController {
   constructor(
     private readonly tailService: TailService,
     private readonly nftService: NftService,
-    private readonly bls: Bls,
   ) { }
 
   @Get()

--- a/src/tail/tail.controller.ts
+++ b/src/tail/tail.controller.ts
@@ -8,7 +8,7 @@ import { Bls } from 'src/bls';
 
 interface TailRevealResponse {
   eve_coin_id: string;
-  eve_puzzle_hash: string;
+  eve_coin_spent_block_index: number;
   tail_hash: string;
   tail_reveal: string;
 }
@@ -79,11 +79,11 @@ export class TailController {
   async getTailReveal(@Param('eveCoinId') eveCoinId: string): Promise<TailRevealResponse> {
     this.logger.log(`GET /reveal/${eveCoinId} called`);
 
-    const [eve_coin_id, eve_puzzle_hash, tail_hash, tail_reveal] = await this.tailService.getTailReveal(eveCoinId);
+    const [eve_coin_id, eve_coin_spent_block_index, tail_hash, tail_reveal] = await this.tailService.getTailReveal(eveCoinId);
 
     return {
       eve_coin_id,
-      eve_puzzle_hash,
+      eve_coin_spent_block_index,
       tail_hash,
       tail_reveal
     };

--- a/src/tail/tail.controller.ts
+++ b/src/tail/tail.controller.ts
@@ -52,12 +52,16 @@ export class TailController {
   }
 
   @Patch()
-  async updateTail(@Headers() headers, @Body() updateTailDto: AddTailDto): Promise<void> {
+  async updateTail(@Headers() headers, @Body() updateTailDto: AddTailDto): Promise<InsertResponse> {
     this.logger.log('PATCH /tail called');
 
     await this.tailService.authorize(updateTailDto.hash, updateTailDto.eveCoinId, headers['x-chia-signature']);
 
-    // Todo: perform update
+    await this.validateTailRecord(updateTailDto);
+
+    this.logger.log('Validation passed');
+
+    return this.tailService.updateTail(updateTailDto);
   }
 
   @Post('/batch/insert')

--- a/src/tail/tail.controller.ts
+++ b/src/tail/tail.controller.ts
@@ -59,7 +59,10 @@ export class TailController {
       throw new BadRequestException('Signature is required');
     }
 
-    const valid = await this.tailService.authorize(updateTailDto.hash, signature);
+    // Eve coin must be of the correct CAT
+    this.validateTailHash(updateTailDto.hash, updateTailDto.eveCoinId);
+
+    const valid = await this.tailService.authorize(updateTailDto.hash, updateTailDto.eveCoinId, signature);
 
     if (!valid) {
       throw new BadRequestException('Invalid signature');
@@ -100,16 +103,23 @@ export class TailController {
       throw new BadRequestException(err.message);
     }
 
-    const [eve_coin_id, _, tail_hash] = await this.tailService.getTailReveal(tailRecord.eveCoinId);
-
-    if (tail_hash !== tailRecord.hash) {
-      throw new BadRequestException(`eveCoinId is not for correct CAT. Expected TAIL hash of ${tailRecord.hash} but found ${tail_hash}`);
-    }
+    // Eve coin must be of the correct CAT
+    const eve_coin_id = this.validateTailHash(tailRecord.hash, tailRecord.eveCoinId);
 
     const nftUri = await this.nftService.getNftUri(tailRecord.launcherId);
 
     if (!nftUri) {
       throw new BadRequestException('Launcher ID does not resolve to an NFT URI');
+    }
+
+    return eve_coin_id;
+  }
+
+  private async validateTailHash(hash, eveCoinId) {
+    const [eve_coin_id, _, tail_hash] = await this.tailService.getTailReveal(eveCoinId);
+
+    if (tail_hash !== hash) {
+      throw new BadRequestException(`eveCoinId is not for correct CAT. Expected TAIL hash of ${hash} but found ${tail_hash}`);
     }
 
     return eve_coin_id;

--- a/src/tail/tail.controller.ts
+++ b/src/tail/tail.controller.ts
@@ -39,7 +39,7 @@ export class TailController {
   async addTail(@Headers() headers, @Body() addTailDto: AddTailDto): Promise<InsertResponse> {
     this.logger.log('POST /tail called');
 
-    // await this.tailService.authorize(addTailDto.hash, addTailDto.eveCoinId, headers['x-chia-signature']);
+    await this.tailService.authorize(addTailDto.hash, addTailDto.eveCoinId, headers['x-chia-signature']);
 
     const eveCoinId = await this.validateTailRecord(addTailDto);
 

--- a/src/tail/tail.controller.ts
+++ b/src/tail/tail.controller.ts
@@ -59,9 +59,6 @@ export class TailController {
       throw new BadRequestException('Signature is required');
     }
 
-    // Eve coin must be of the correct CAT
-    this.validateTailHash(updateTailDto.hash, updateTailDto.eveCoinId);
-
     const valid = await this.tailService.authorize(updateTailDto.hash, updateTailDto.eveCoinId, signature);
 
     if (!valid) {
@@ -104,22 +101,12 @@ export class TailController {
     }
 
     // Eve coin must be of the correct CAT
-    const eve_coin_id = this.validateTailHash(tailRecord.hash, tailRecord.eveCoinId);
+    const eve_coin_id = this.tailService.validateTailHash(tailRecord.hash, tailRecord.eveCoinId);
 
     const nftUri = await this.nftService.getNftUri(tailRecord.launcherId);
 
     if (!nftUri) {
       throw new BadRequestException('Launcher ID does not resolve to an NFT URI');
-    }
-
-    return eve_coin_id;
-  }
-
-  private async validateTailHash(hash, eveCoinId) {
-    const [eve_coin_id, _, tail_hash] = await this.tailService.getTailReveal(eveCoinId);
-
-    if (tail_hash !== hash) {
-      throw new BadRequestException(`eveCoinId is not for correct CAT. Expected TAIL hash of ${hash} but found ${tail_hash}`);
     }
 
     return eve_coin_id;

--- a/src/tail/tail.service.ts
+++ b/src/tail/tail.service.ts
@@ -39,6 +39,10 @@ export class TailService {
         return this.tail.insert(tailRecord);
     }
 
+    async updateTail(tailRecord: TailRecord): Promise<InsertResponse> {
+        return this.tail.update(tailRecord);
+    }
+
     async addTails(tailRecords: TailRecord[]): Promise<InsertResponse> {
         const hashes = new Map<string, boolean>();
         const codes = new Map<string, boolean>();

--- a/src/tail/tail.service.ts
+++ b/src/tail/tail.service.ts
@@ -58,11 +58,11 @@ export class TailService {
         return eve_coin.coin_record.coin.puzzle_hash;
     }
 
-    public async getEveCoinParentAddress(hash: string): Promise<string> {
-        const tail = await this.tail.get(hash);
-        const eve_coin = await this.coin.get_coin_record_by_name(tail.eveCoinId);
+    public async getParentPuzzleHash(coinId: string): Promise<string> {
+        const eve_coin = await this.coin.get_coin_record_by_name(coinId);
+        const eve_coin_parent = await this.coin.get_coin_record_by_name(eve_coin.coin_record.coin.parent_coin_info);
 
-        return eve_coin.coin_record.coin.parent_coin_info;
+        return eve_coin_parent.coin_record.coin.puzzle_hash;
     }
 
     public async authorize(hash: string, request_signature: string): Promise<boolean> {

--- a/src/tail/tail.service.ts
+++ b/src/tail/tail.service.ts
@@ -72,6 +72,10 @@ export class TailService {
     }
 
     public async authorize(hash: string, eveCoinId: string, request_signature: string): Promise<boolean> {
+        if (!request_signature) {
+            throw new BadRequestException('Signature is required');
+        }
+
         // Eve coin must be of the correct CAT
         this.validateTailHash(hash, eveCoinId);
 
@@ -105,11 +109,15 @@ export class TailService {
                 const synthetic_pk = this.bls.getPublicKey(synthetic_pk_hex);
 
                 // Verify signature against key of parent of eve
-                return this.bls.verify(synthetic_pk, message, signature)
+                const valid = this.bls.verify(synthetic_pk, message, signature);
+
+                if (valid) {
+                    return;
+                }
             }
         }
 
-        return false;
+        throw new BadRequestException('Invalid signature');
     }
 
     async getTailReveal(eveCoinId: string): Promise<[string, number, string, string]> {

--- a/src/tail/tail.service.ts
+++ b/src/tail/tail.service.ts
@@ -77,7 +77,7 @@ export class TailService {
         }
 
         // Eve coin must be of the correct CAT
-        this.validateTailHash(hash, eveCoinId);
+        await this.validateTailHash(hash, eveCoinId);
 
         const auth_message = SExp.to("Chia Signed Message").cons(this.authService.getAuthorizationMessage());
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,0 +1,17 @@
+import crypto from 'crypto';
+
+export const getCurrentHour = (): Date => {
+    const now = new Date();
+
+    now.setMinutes(0, 0, 0);
+
+    return now;
+};
+
+export const sha256 = (input: string): string => crypto.createHash('sha256').update(input).digest('hex');
+
+export const strip_hex_prefix = (str: string) =>
+    str.startsWith('0x') ? str.slice(2) : str;
+
+export const hex_to_buffer = (hex: string) =>
+    Buffer.from(strip_hex_prefix(hex), 'hex');


### PR DESCRIPTION
This introduces a new `/auth/:hash` endpoint which provides a message and address. The address is the one which was used to originally mint the CAT with the provided tail hash.

When adding or updating data in Tail Database you need to sign the message using the address and pass the signature as a header. The easiest way to sign is using the [sign_message CLI](https://docs.chia.net/wallet-cli#sign_message) or [sign_message_by_address RPC](https://docs.chia.net/wallet-rpc#sign_message_by_address).